### PR TITLE
Removal of REST calls to Dockerhub to rely on Python's Docker API only

### DIFF
--- a/src/Resources/api/DockerHubApi.py
+++ b/src/Resources/api/DockerHubApi.py
@@ -4,36 +4,12 @@ import requests
 
 from ..exceptions import HTTPConnectionError
 
-DOCKER_HUB_IMAGE_URL = "https://hub.docker.com/v2/repositories/%s/tags/%s/"
 DOCKER_HUB_KATHARA_URL = "https://hub.docker.com/v2/repositories/kathara/?page_size=-1"
 
 EXCLUDED_IMAGES = ['megalos-bgp-manager', 'katharanp']
 
 
 class DockerHubApi(object):
-    @staticmethod
-    def get_image_information(image_name):
-        tag = 'latest'
-        img_name = image_name
-        if ':' in image_name:
-            split_name = image_name.split(':')
-            img_name, tag = split_name[0], split_name[1]
-        if '/' not in img_name:
-            img_name = 'library/%s' % img_name
-
-        try:
-            result = requests.get(DOCKER_HUB_IMAGE_URL % (img_name, tag))
-        except requests.exceptions.ConnectionError as e:
-            raise HTTPConnectionError(str(e))
-
-        if result.status_code != 200:
-            logging.debug("DockerHub replied with status code %s while looking for image %s.",
-                          result.status_code,
-                          image_name
-                          )
-            raise HTTPConnectionError("DockerHub replied with status code %s." % result.status_code)
-
-        return result.json()
 
     @staticmethod
     def get_images():

--- a/src/Resources/manager/docker/DockerImage.py
+++ b/src/Resources/manager/docker/DockerImage.py
@@ -27,8 +27,8 @@ class DockerImage(object):
     def check_update(self, image_name):
         logging.debug("Check update for %s" % image_name)
 
-        if '/' not in image_name:
-            logging.debug('Cannot check image digest because %s is a library/<image>' % image_name)
+        if '@' in image_name:
+            logging.debug('No need to check image digest of %s' % image_name)
             return
 
         local_image_info = self.check_local(image_name)
@@ -46,7 +46,7 @@ class DockerImage(object):
         # Format is image_name@sha256, so we strip the first part.
         (_, local_image_digest) = local_repo_digest.split("@")
         # We only need to update tagged images, not the ones with digests.
-        if (remote_image_digest != local_image_digest) and '@' not in image_name:
+        if remote_image_digest != local_image_digest:
             utils.confirmation_prompt("A new version of image `%s` has been found on Docker Hub. "
                                       "Do you want to pull it?" % image_name,
                                       lambda: self.pull(image_name),

--- a/src/kathara.py
+++ b/src/kathara.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import argparse
 import logging
@@ -98,7 +98,7 @@ class KatharaEntryPoint(object):
 
 if __name__ == '__main__':
     utils.check_python_version()
-    
+
     utils.exec_by_platform(PrivilegeHandler.get_instance().drop_privileges, lambda: None, lambda: None)
 
     try:
@@ -107,5 +107,5 @@ if __name__ == '__main__':
         debug_level = "DEBUG"
 
     coloredlogs.install(fmt='%(levelname)s - %(message)s', level=debug_level)
-    
+
     KatharaEntryPoint()


### PR DESCRIPTION
Hi, I did recognize your pull request to Kathara. However, the digests are not working as expected in Docker. If it is a multiarchitecture image, the digest, which is received with REST over Dockerhub, never matches the local one (Dockerhub-Feedback [Issue 1925](https://github.com/docker/hub-feedback/issues/1925)). I propose that we get rid of the REST implementation and completely rely on Python's Docker API.  